### PR TITLE
replaced the input field for vocab time with a dropdown menu

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -10,10 +10,13 @@ const addTermForm = (uid, word = {}) => {
         <label for="title">Term</label>
         <input type="text" class="form-control" id="term-name" aria-describedby="termName" placeholder="Enter Term" value="${word.term || ''}" required>
       </div>
-      <div class="form-group">
-        <label for="title">Vocab Type</label>
-        <input type="text" class="form-control" id="vocab-type" aria-describedby="vocabType" placeholder="Type" value="${word.vocabType || ''}" required>
-      </div>
+      <select id="vocab-type" class="form-select" aria-label="Default select example">
+          <option selected disabled>${word.vocabType || 'Select Vocabulary Type'}</option>
+          <option value="${word.vocabType || 'Keyword'}">Keyword</option>
+          <option value="${word.vocabType || 'Turn structure'}">Turn structure</option>
+          <option value="${word.vocabType || 'Lingo'}">Lingo</option>
+          <option value="${word.vocabType || 'Card type'}">Card type</option>
+      </select>
       <div class="form-group">
         <label for="description">Definition</label>
         <textarea class="form-control" placeholder="Definition" id="definition" style="height: 100px">${word.definition || ''}</textarea>


### PR DESCRIPTION
## Description
replaced the input field with a dropdown menu to restrict naming conventions

## Related Issue
#11 
#16 


## Motivation and Context
makes the naming conventions for the vocab type more strict allowing for filtering effectively

## How Can This Be Tested?
click the term type in the submit/update form

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
